### PR TITLE
Fix nullable annotation context in two SmartQuery properties

### DIFF
--- a/MediaBrowser.Controller/Collections/CollectionCreationOptions.cs
+++ b/MediaBrowser.Controller/Collections/CollectionCreationOptions.cs
@@ -32,6 +32,8 @@ namespace MediaBrowser.Controller.Collections
         /// <summary>
         /// Gets or sets the smart query used for automatically selecting items.
         /// </summary>
+#nullable enable
         public string? SmartQuery { get; set; }
+#nullable disable
     }
 }

--- a/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
+++ b/MediaBrowser.Controller/Entities/Movies/BoxSet.cs
@@ -50,7 +50,9 @@ namespace MediaBrowser.Controller.Entities.Movies
         /// <summary>
         /// Gets or sets the smart query used to automatically fill this collection.
         /// </summary>
+#nullable enable
         public string? SmartQuery { get; set; }
+#nullable disable
 
         [JsonIgnore]
         private bool IsLegacyBoxSet


### PR DESCRIPTION
## Summary
- add `#nullable` regions around `SmartQuery` properties

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f177134ac8332914cbc1660b0988d