### PR TITLE
Fix missing using for User entity

### DIFF
--- a/Emby.Server.Implementations/Collections/SmartCollectionHelper.cs
+++ b/Emby.Server.Implementations/Collections/SmartCollectionHelper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
+using Jellyfin.Database.Implementations.Entities;
 
 namespace Emby.Server.Implementations.Collections
 {


### PR DESCRIPTION
## Summary
- include Jellyfin.Database User namespace in SmartCollectionHelper

## Testing
- `dotnet build Jellyfin.Server` *(fails: A compatible .NET SDK was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1cbf00ac83328ec4469dc6a759ef