### PR TITLE
Fix using directive order

### DIFF
--- a/Emby.Server.Implementations/Collections/SmartCollectionHelper.cs
+++ b/Emby.Server.Implementations/Collections/SmartCollectionHelper.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Jellyfin.Database.Implementations.Entities;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
-using Jellyfin.Database.Implementations.Entities;
 
 namespace Emby.Server.Implementations.Collections
 {


### PR DESCRIPTION
## Summary
- sort using directives alphabetically in `SmartCollectionHelper`

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1e1f89b483328b45f8e7289ba564